### PR TITLE
Ajout de la page "Comment agir" et refonte de la page webinaire /rdv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ DEBUG=True
 
 # Frontend settings (VITE_* variables are exposed to the frontend)
 VITE_BACKEND_URL=http://localhost:8000
-VITE_CONTACT_EMAIL=
-VITE_RDV_PAGE_URL=https://rdv.numerique.gouv.fr/motif/XFE5HwoJ/1-webinaire-de-presentation-protect-envi-60-min-comprendre-co
+VITE_CONTACT_EMAIL=todo@todo.com
+VITE_RDV_PAGE_URL=https://TODO
 
 # Matomo Analytics
 VITE_MATOMO_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ DEBUG=True
 # Frontend settings (VITE_* variables are exposed to the frontend)
 VITE_BACKEND_URL=http://localhost:8000
 VITE_CONTACT_EMAIL=
-VITE_RDV_PAGE_URL=https://rdv.anct.gouv.fr/prendre_rdv?departement=&public_link_organisation_id=1769
+VITE_RDV_PAGE_URL=https://rdv.numerique.gouv.fr/motif/XFE5HwoJ/1-webinaire-de-presentation-protect-envi-60-min-comprendre-co
 
 # Matomo Analytics
 VITE_MATOMO_ENABLED=false

--- a/frontend/composables/useTally.ts
+++ b/frontend/composables/useTally.ts
@@ -6,6 +6,7 @@ interface TallyRouteConfig {
   [path: string]: {
     formId: string
     options?: TallyPopupOptions
+    returnPath?: string
   }
 }
 
@@ -23,9 +24,9 @@ export function useTallyRoutes(config: TallyRouteConfig) {
       openTallyPopup(setup.formId, {
         ...setup.options,
         onClose: () => {
-          // If we are still on the specific route when closing, go back to home
+          // If we are still on the specific route when closing, go back to the return path
           if (route.path === path) {
-            router.push('/')
+            router.push(setup.returnPath ?? '/')
           }
           // Call original onClose if provided
           if (setup.options?.onClose) {

--- a/frontend/layouts/default-layout.vue
+++ b/frontend/layouts/default-layout.vue
@@ -116,7 +116,7 @@ interface NavLink {
 const navLinks = computed<NavLink[]>(() => {
   const links = [
     { text: 'Accueil', href: '/' },
-    { text: 'Comprendre la procédure', href: '/comprendre-la-procedure' },
+    { text: 'Comment agir', href: '/comment-agir' },
     { text: 'Mes procédures', href: '/mes-procedures' },
     { text: 'FAQ', href: '/faq' },
     { text: 'Contact', href: '/contact' },

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -202,6 +202,11 @@ const router = createRouter({
       name: 'PlanDuSite',
       component: () => import('./pages/plan-du-site.vue'),
     },
+    {
+      path: '/comment-agir',
+      name: 'CommentAgir',
+      component: () => import('./pages/comment-agir.vue'),
+    },
   ],
 })
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -115,6 +115,12 @@ const router = createRouter({
       meta: { title: 'Prendre rendez-vous' },
     },
     {
+      path: '/rdv/etre-informe',
+      name: 'RDVEtreInforme',
+      component: () => import('./pages/rdv.vue'),
+      meta: { title: 'Prendre rendez-vous' },
+    },
+    {
       path: '/login-demo',
       name: 'LoginDemo',
       component: () => import('./pages/login-demo.vue'),
@@ -205,6 +211,11 @@ const router = createRouter({
     {
       path: '/comment-agir',
       name: 'CommentAgir',
+      component: () => import('./pages/comment-agir.vue'),
+    },
+    {
+      path: '/comment-agir/etre-informe',
+      name: 'CommentAgirEtreInforme',
       component: () => import('./pages/comment-agir.vue'),
     },
   ],

--- a/frontend/pages/comment-agir.vue
+++ b/frontend/pages/comment-agir.vue
@@ -58,14 +58,14 @@
           <span>Les collectivités peuvent agir</span>
         </h2>
         <p class="fr-text fr-text--bold">
-          Les collectivités disposent d'un véritable pouvoir d'action grâce à la procédure
-          administrative.
+          Avec la procédure administrative, les collectivités disposent d'un véritable pouvoir
+          d'action.
         </p>
         <p class="fr-text">
           Contrairement à une idée reçue, il n'est pas toujours nécessaire de déposer plainte pour
           agir contre un dépôt sauvage.
         </p>
-        <p class="fr-text fr-mb-1w">Grâce à la procédure administrative, la collectivité peut :</p>
+        <p class="fr-text fr-mb-1w">Cette procédure permet à la collectivité de : </p>
         <ul class="fr-p-0 fr-mb-0" style="list-style: none">
           <li class="fr-mb-1w fr-display-flex">
             <span

--- a/frontend/pages/comment-agir.vue
+++ b/frontend/pages/comment-agir.vue
@@ -1,0 +1,289 @@
+<template>
+  <div>
+    <div class="fr-background-alt--blue-france fr-mb-6w fr-py-6w">
+      <div class="fr-container">
+        <h1 class="fr-h1 fr-mb-3w">Comment agir contre les dépôts sauvages ?</h1>
+        <p class="fr-text fr-text--lead">
+          Les maires et les présidents d'intercommunalité disposent d'un levier efficace pour agir
+          contre les dépôts sauvages. Grâce à la procédure administrative, ils peuvent obtenir le
+          nettoyage d'un dépôt ou sanctionner son auteur lorsqu'il est identifié.
+        </p>
+
+        <p class="fr-text fr-text--bold fr-mb-1w">Sur cette page, vous découvrirez :</p>
+        <ul class="fr-p-0 fr-mb-2w" style="list-style: none">
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>les avantages de la procédure administrative pour lutter contre les dépôts sauvages</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>les grandes étapes de la procédure</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>les réponses aux questions les plus fréquentes</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>
+              comment aller plus loin grâce à notre webinaire d'accompagnement (
+              <router-link to="/rdv" class="fr-link">Je m'inscris au prochain wébinaire</router-link>
+              )
+            </span>
+          </li>
+        </ul>
+        <p class="fr-text--sm fr-hint-text fr-mb-0">
+          <span class="fr-icon-time-line fr-mr-1w" aria-hidden="true"></span>
+          Lecture : 5 minutes
+        </p>
+      </div>
+    </div>
+
+    <div class="fr-container fr-pb-8w">
+      <section class="fr-mb-7w">
+        <h2 class="fr-h3 fr-mb-3w">
+          <span class="fr-icon-shield-check-line fr-mr-1w" aria-hidden="true"></span>
+          <span>Les collectivités peuvent agir</span>
+        </h2>
+        <p class="fr-text fr-text--bold">
+          Les collectivités disposent d'un véritable pouvoir d'action grâce à la procédure
+          administrative.
+        </p>
+        <p class="fr-text">
+          Contrairement à une idée reçue, il n'est pas toujours nécessaire de déposer plainte pour
+          agir contre un dépôt sauvage.
+        </p>
+        <p class="fr-text fr-mb-1w">Grâce à la procédure administrative, la collectivité peut :</p>
+        <ul class="fr-p-0 fr-mb-0" style="list-style: none">
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>agir directement contre un auteur identifié</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>obtenir le nettoyage du dépôt par l'auteur</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span
+              >prononcer une amende administrative jusqu'à
+              <strong>15&nbsp;000&nbsp;€</strong> et éviter les classements sans suite</span
+            >
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>percevoir les recettes de cette amende</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="fr-mb-7w">
+        <h2 class="fr-h3 fr-mb-1w">
+          <span class="fr-icon-road-map-line fr-mr-1w" aria-hidden="true"></span>
+          <span>Les grandes étapes pour traiter un dépôt sauvage</span>
+        </h2>
+        <p class="fr-text fr-mb-4w">
+          Comment une collectivité peut engager une procédure administrative.
+        </p>
+
+        <div class="fr-grid-row fr-grid-row--gutters">
+          <div v-for="step in steps" :key="step.badge" class="fr-col-12 fr-col-md-6">
+            <article class="fr-card fr-card--shadow fr-card--no-arrow fr-p-3w fr-mb-0" style="height: 100%">
+              <div class="fr-card__body">
+                <h3 class="fr-h5 fr-mb-2w fr-display-flex fr-flex-wrap fr-gap-1w">
+                  <DsfrBadge class="fr-mr-1w" :label="step.badge" type="info" :small="false" />
+                  <span>{{ step.title }}</span>
+                </h3>
+                <p class="fr-text fr-mb-0">{{ step.description }}</p>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <DsfrCallout class="fr-mt-4w fr-mb-0" title="Vous souhaitez comprendre chaque étape en détail ?">
+          <router-link to="/comprendre-la-procedure" class="fr-link">
+            Consulter le guide complet de la procédure administrative
+          </router-link>
+        </DsfrCallout>
+      </section>
+
+      <section class="fr-mb-7w">
+        <h2 class="fr-h3 fr-mb-3w">
+          <span class="fr-icon-question-line fr-mr-1w" aria-hidden="true"></span>
+          <span>Les questions les plus fréquentes</span>
+        </h2>
+        <ul class="fr-pl-0 fr-mb-3w" style="list-style: none">
+          <li v-for="item in faqItems" :key="item.slug" class="fr-mb-2w">
+            <router-link :to="`/faq/${item.slug}`" class="fr-link fr-text--bold">
+              {{ item.question }}
+            </router-link>
+          </li>
+        </ul>
+        <router-link to="/faq" class="fr-btn fr-btn--secondary">
+          Trouver la réponse à votre question
+        </router-link>
+      </section>
+
+      <section>
+        <article class="fr-card fr-card--shadow fr-card--no-arrow fr-p-4w">
+          <div class="fr-card__body">
+            <h2 class="fr-h3 fr-mb-1w">
+              <span class="fr-icon-live-line fr-mr-1w" aria-hidden="true"></span>
+              <span>Participez à notre prochain webinaire</span>
+            </h2>
+            <p class="fr-text fr-text--bold">
+              En moins de 60 minutes, découvrez comment les collectivités peuvent agir concrètement
+              contre les dépôts sauvages.
+            </p>
+            <p class="fr-text">
+              Chaque semaine, les équipes de Protect'Envi présentent la procédure administrative,
+              expliquent des cas concrets et répondent aux questions des collectivités sur leurs
+              moyens d'agir contre les dépôts sauvages.
+            </p>
+            <p class="fr-text fr-text--bold fr-mb-1w">À l'issue du webinaire, vous saurez :</p>
+            <ul class="fr-p-0 fr-mb-3w" style="list-style: none">
+              <li class="fr-mb-1w fr-display-flex">
+                <span
+                  class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+                  aria-hidden="true"
+                ></span>
+                <span>quand utiliser la procédure administrative</span>
+              </li>
+              <li class="fr-mb-1w fr-display-flex">
+                <span
+                  class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+                  aria-hidden="true"
+                ></span>
+                <span>comment traiter votre premier dépôt sauvage</span>
+              </li>
+              <li class="fr-mb-1w fr-display-flex">
+                <span
+                  class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+                  aria-hidden="true"
+                ></span>
+                <span>les bonnes pratiques à appliquer et les erreurs à éviter</span>
+              </li>
+              <li class="fr-mb-1w fr-display-flex">
+                <span
+                  class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+                  aria-hidden="true"
+                ></span>
+                <span>comment répondre aux situations les plus fréquentes</span>
+              </li>
+            </ul>
+            <p class="fr-text--sm fr-hint-text fr-mb-4w">
+              Toutes vos questions pourront être posées en direct à un membre de notre équipe.
+            </p>
+
+            <router-link to="/rdv" class="fr-btn fr-btn--lg fr-mb-4w">
+              Je m'inscris au prochain webinaire
+            </router-link>
+
+            <div class="fr-pt-4w" style="border-top: 1px solid var(--border-default-grey)">
+              <h3 class="fr-h6 fr-mb-1w">Vous ne pouvez pas participer ?</h3>
+              <p class="fr-text fr-mb-2w">
+                Recevez un récapitulatif des informations essentielles ainsi que les prochaines
+                dates de webinaire.
+              </p>
+              <TallyPopupButton
+                form-id="Pdyay0"
+                label="Je souhaite recevoir les ressources clés et les prochaines dates par e-mail"
+                variant="secondary"
+              />
+            </div>
+          </div>
+        </article>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import TallyPopupButton from '@/components/shared/TallyPopupButton.vue'
+import { DsfrBadge, DsfrCallout } from '@gouvminint/vue-dsfr'
+
+const steps = [
+  {
+    badge: 'Étape 1',
+    title: 'Identification',
+    description: "Rechercher les éléments permettant d'identifier un auteur présumé.",
+  },
+  {
+    badge: 'Étape 2',
+    title: 'Constatation',
+    description: 'Une personne habilitée établit le rapport de constatation.',
+  },
+  {
+    badge: 'Étape 3',
+    title: 'Information',
+    description:
+      "L'auteur présumé est informé par courrier et dispose d'un délai pour présenter ses observations.",
+  },
+  {
+    badge: 'Étape 4',
+    title: 'Décision',
+    description: "Le maire ou le président d'intercommunalité décide de sanctionner l'auteur ou non.",
+  },
+  {
+    badge: 'Étape 5',
+    title: 'Exécution',
+    description:
+      'La procédure peut aboutir au retrait des déchets et/ou à une amende administrative recouvrée au profit de la mairie.',
+  },
+]
+
+const faqItems = [
+  {
+    question: 'Dois-je obligatoirement déposer plainte ?',
+    slug: 'dois-je-obligatoirement-deposer-plainte-pour-engager-une-procedure-contre-un-depot-sauvage',
+  },
+  {
+    question: 'Est-ce que je peux retirer le dépôt sauvage immédiatement ?',
+    slug: 'peut-on-retirer-un-depot-sauvage-immediatement',
+  },
+  {
+    question: 'Comment identifier un auteur ?',
+    slug: 'comment-identifier-lauteur',
+  },
+  {
+    question: "Faut-il une délibération du conseil municipal pour lancer une procédure administrative ?",
+    slug: 'faut-il-une-deliberation-du-conseil-municipal-pour-demarrer-une-procedure-administrative',
+  },
+  {
+    question: 'Puis-je agir sur un terrain privé ?',
+    slug: 'peut-on-engager-une-procedure-si-le-depot-est-sur-un-terrain-prive',
+  },
+  {
+    question: 'Qui peut constater un dépôt sauvage ?',
+    slug: 'qui-peut-constater-un-depot-sauvage',
+  },
+  {
+    question: 'Puis-je utiliser Stop dépôt sauvage si ma commune est en zone police nationale ?',
+    slug: 'puis-je-utiliser-protectenvi-si-ma-commune-est-en-zone-police-nationale',
+  },
+]
+</script>

--- a/frontend/pages/comment-agir.vue
+++ b/frontend/pages/comment-agir.vue
@@ -54,7 +54,7 @@
     <div class="fr-container fr-pb-8w">
       <section class="fr-mb-7w">
         <h2 class="fr-h3 fr-mb-3w">
-          <span class="fr-icon-shield-check-line fr-mr-1w" aria-hidden="true"></span>
+          <span class="fr-icon-shield-line fr-mr-1w" aria-hidden="true"></span>
           <span>Les collectivités peuvent agir</span>
         </h2>
         <p class="fr-text fr-text--bold">
@@ -143,8 +143,8 @@
             </router-link>
           </li>
         </ul>
-        <router-link to="/faq" class="fr-btn fr-btn--secondary">
-          Trouver la réponse à votre question
+        <router-link to="/faq" class="fr-link fr-link--icon-right fr-icon-arrow-right-line">
+          Consulter toutes les questions fréquentes
         </router-link>
       </section>
 
@@ -213,6 +213,7 @@
                 form-id="Pdyay0"
                 label="Je souhaite recevoir les ressources clés et les prochaines dates par e-mail"
                 variant="secondary"
+                to="/comment-agir/etre-informe"
               />
             </div>
           </div>
@@ -224,7 +225,16 @@
 
 <script setup lang="ts">
 import TallyPopupButton from '@/components/shared/TallyPopupButton.vue'
+import { useTallyRoutes } from '@/composables/useTally'
 import { DsfrBadge, DsfrCallout } from '@gouvminint/vue-dsfr'
+
+useTallyRoutes({
+  '/comment-agir/etre-informe': {
+    formId: 'Pdyay0',
+    options: { layout: 'modal', width: 900 },
+    returnPath: '/comment-agir',
+  },
+})
 
 const steps = [
   {
@@ -276,14 +286,6 @@ const faqItems = [
   {
     question: 'Puis-je agir sur un terrain privé ?',
     slug: 'peut-on-engager-une-procedure-si-le-depot-est-sur-un-terrain-prive',
-  },
-  {
-    question: 'Qui peut constater un dépôt sauvage ?',
-    slug: 'qui-peut-constater-un-depot-sauvage',
-  },
-  {
-    question: 'Puis-je utiliser Stop dépôt sauvage si ma commune est en zone police nationale ?',
-    slug: 'puis-je-utiliser-protectenvi-si-ma-commune-est-en-zone-police-nationale',
   },
 ]
 </script>

--- a/frontend/pages/rdv.vue
+++ b/frontend/pages/rdv.vue
@@ -118,9 +118,14 @@
         <p class="fr-text fr-mb-1w">Nous vous informerons :</p>
         <ul class="fr-pl-3w fr-mb-3w">
           <li class="fr-mb-1w">des prochaines dates des webinaires ;</li>
-          <li class="fr-mb-0">des nouveautés de Stop dépôt sauvage.</li>
+          <li class="fr-mb-0">des nouveautés de Protect'Envi.</li>
         </ul>
-        <TallyPopupButton form-id="Pdyay0" label="📩 Je souhaite être informé" variant="primary" />
+        <TallyPopupButton
+          form-id="Pdyay0"
+          label="📩 Je souhaite être informé"
+          variant="primary"
+          to="/rdv/etre-informe"
+        />
       </section>
     </div>
   </div>
@@ -128,6 +133,15 @@
 
 <script setup lang="ts">
 import TallyPopupButton from '@/components/shared/TallyPopupButton.vue'
+import { useTallyRoutes } from '@/composables/useTally'
 
 const anctLink = import.meta.env.VITE_RDV_PAGE_URL || ''
+
+useTallyRoutes({
+  '/rdv/etre-informe': {
+    formId: 'Pdyay0',
+    options: { layout: 'modal', width: 900 },
+    returnPath: '/rdv',
+  },
+})
 </script>

--- a/frontend/pages/rdv.vue
+++ b/frontend/pages/rdv.vue
@@ -2,65 +2,132 @@
   <div>
     <div class="fr-background-alt--blue-france fr-mb-6w fr-py-6w">
       <div class="fr-container">
-        <h1 class="fr-h1 fr-mb-3w">Prenez rendez-vous avec Protect'Envi</h1>
-        <p class="fr-text fr-text--lead fr-mb-0">
-          Inscrivez-vous à notre prochain webinaire pour comprendre comment mieux lutter contre les
-          dépôts sauvages dans votre collectivité.
+        <h1 class="fr-h1 fr-mb-3w">Participez à notre prochain webinaire</h1>
+        <p class="fr-text fr-text--lead fr-mb-3w">
+          En moins de 60 minutes, découvrez comment les collectivités peuvent agir concrètement
+          contre les dépôts sauvages grâce à la procédure administrative.
         </p>
+        <a :href="anctLink" target="_blank" rel="noopener noreferrer" class="fr-btn fr-btn--lg">
+          🎥 Je m'inscris au wébinaire via RDV service public
+        </a>
       </div>
     </div>
 
     <div class="fr-container fr-pb-8w">
-      <div class="fr-grid-row">
-        <div class="fr-col-12 fr-col-md-10">
-          <DsfrCard :link="anctLink" enlarge-link class="rdv-card fr-p-2w" :title="title">
-            <template #start-details>
-              <div class="fr-badges-group fr-mb-2v">
-                <span class="fr-badge fr-badge--info fr-badge--sm fr-badge--no-icon">
-                  <span
-                    class="fr-icon-computer-line fr-icon--sm fr-mr-1v"
-                    aria-hidden="true"
-                  ></span>
-                  PAR VISIOCONFÉRENCE
-                </span>
-                <span class="fr-badge fr-badge--purple-glycine fr-badge--sm fr-badge--no-icon">
-                  <span class="fr-icon-team-line fr-icon--sm fr-mr-1v" aria-hidden="true"></span>
-                  RDV COLLECTIF
-                </span>
-              </div>
-            </template>
-          </DsfrCard>
-        </div>
+      <section class="fr-mb-4w">
+        <h2 class="fr-h4 fr-mb-3w">Pendant ce webinaire, vous découvrirez :</h2>
+        <ul class="fr-p-0 fr-mb-0" style="list-style: none">
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>quand utiliser la procédure administrative</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>comment traiter votre premier dépôt sauvage</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>les bonnes pratiques à appliquer et les erreurs à éviter</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span
+              class="fr-icon-checkbox-circle-fill fr-text-default--success fr-mr-1w"
+              aria-hidden="true"
+            ></span>
+            <span>comment répondre aux situations les plus fréquentes</span>
+          </li>
+        </ul>
+      </section>
+
+      <hr class="fr-my-4w" />
+
+      <section class="fr-mb-4w">
+        <h2 class="fr-h4 fr-mb-3w">À qui s'adresse ce wébinaire</h2>
+        <ul class="fr-p-0 fr-mb-0" style="list-style: none">
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">👨‍💼</span>
+            <span>Maires, présidents d'intercommunalité et élus en charge du sujet</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">🏛️</span>
+            <span>Directions générales des services (DGS) et agents administratifs</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">👮</span>
+            <span>Polices municipales et gardes champêtres</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">🚛</span>
+            <span>Services techniques et environnement</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">👮</span>
+            <span>Gendarmes ou policiers accompagnant les collectivités</span>
+          </li>
+          <li class="fr-mb-0 fr-display-flex">
+            <span class="fr-mr-1w" aria-hidden="true">🏘️</span>
+            <span>Toute personne impliquée dans la gestion des dépôts sauvages au sein d'une collectivité</span>
+          </li>
+        </ul>
+      </section>
+
+      <hr class="fr-my-4w" />
+
+      <section class="fr-mb-4w">
+        <h2 class="fr-h4 fr-mb-3w">Informations pratiques</h2>
+        <ul class="fr-p-0 fr-mb-0" style="list-style: none">
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-icon-calendar-line fr-mr-1w" aria-hidden="true"></span>
+            <span>Toutes les semaines</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-icon-time-line fr-mr-1w" aria-hidden="true"></span>
+            <span>Durée : 45 à 60 minutes</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-icon-money-euro-circle-line fr-mr-1w" aria-hidden="true"></span>
+            <span>Gratuit</span>
+          </li>
+          <li class="fr-mb-1w fr-display-flex">
+            <span class="fr-icon-computer-line fr-mr-1w" aria-hidden="true"></span>
+            <span>En visioconférence</span>
+          </li>
+        </ul>
+      </section>
+
+      <div class="fr-mb-4w">
+        <a :href="anctLink" target="_blank" rel="noopener noreferrer" class="fr-btn fr-btn--lg">
+          🎥 Je m'inscris au wébinaire via RDV service public
+        </a>
       </div>
+
+      <hr class="fr-my-4w" />
+
+      <section>
+        <h2 class="fr-h4 fr-mb-2w">Et si vous n'êtes pas disponible ?</h2>
+        <p class="fr-text fr-mb-1w">Laissez-nous votre adresse e-mail.</p>
+        <p class="fr-text fr-mb-1w">Nous vous informerons :</p>
+        <ul class="fr-pl-3w fr-mb-3w">
+          <li class="fr-mb-1w">des prochaines dates des webinaires ;</li>
+          <li class="fr-mb-0">des nouveautés de Stop dépôt sauvage.</li>
+        </ul>
+        <TallyPopupButton form-id="Pdyay0" label="📩 Je souhaite être informé" variant="primary" />
+      </section>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { DsfrCard } from '@gouvminint/vue-dsfr'
+import TallyPopupButton from '@/components/shared/TallyPopupButton.vue'
 
-const title =
-  "🧑‍💻 Webinaire de présentation Protect'Envi (60 min) : Comprendre comment mieux lutter contre les dépôts sauvages"
 const anctLink = import.meta.env.VITE_RDV_PAGE_URL || ''
 </script>
-
-<style scoped>
-.rdv-card {
-  background-color: var(--background-default-grey);
-  border: 1px solid var(--border-default-grey);
-  transition:
-    background-color 0.2s ease-in-out,
-    transform 0.2s ease-in-out,
-    box-shadow 0.2s ease-in-out;
-}
-
-.rdv-card:hover {
-  background-color: var(--background-alt-grey);
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-raised-shadow);
-}
-
-.fr-card__title {
-  color: var(--text-title-blue-france);
-}
-</style>


### PR DESCRIPTION
## Résumé
- Nouvelle page statique `/comment-agir` (1ère version du parcours "Comprendre comment agir") : bénéfices de la procédure administrative, 5 étapes clés, FAQ liée aux entrées dédiées de la FAQ générale, renvoi vers le webinaire.
- Remplacement de "Comprendre la procédure" par "Comment agir" dans le menu principal (page toujours accessible via lien direct et le bloc étapes de "Comment agir").
- Refonte de la page webinaire `/rdv` : programme du webinaire, public cible, informations pratiques, inscription via RDV Service Public, capture d'e-mail (Tally) pour les indisponibles.
- Mise à jour du lien RDV Service Public (`VITE_RDV_PAGE_URL`) vers le motif dédié au webinaire.

## Test plan
- [x] Rendu vérifié dans le navigateur (page `/comment-agir` et `/rdv`), desktop et mobile
- [x] Aucune erreur console
- [x] Popup Tally testé (ouverture, contenu du formulaire)
- [x] Liens FAQ vérifiés (routes `/faq/{slug}` fonctionnelles, contenu dépendant des données FAQ en prod)
- [x] Lien RDV Service Public vérifié

🤖 Generated with [Claude Code](https://claude.com/claude-code)
