### PR TITLE
Simplifier la page démarrer-constatation

### DIFF
--- a/frontend/composables/useTally.ts
+++ b/frontend/composables/useTally.ts
@@ -1,5 +1,5 @@
-import { openTallyPopup, type TallyPopupOptions } from '@/utils/tally'
-import { onMounted, watch } from 'vue'
+import { openTallyPopup, closeTallyPopup, type TallyPopupOptions } from '@/utils/tally'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 interface TallyRouteConfig {
@@ -17,10 +17,15 @@ interface TallyRouteConfig {
 export function useTallyRoutes(config: TallyRouteConfig) {
   const route = useRoute()
   const router = useRouter()
+  let activeFormId: string | null = null
 
   const handleTallyRoute = (path: string) => {
     const setup = config[path]
     if (setup) {
+      if (activeFormId && activeFormId !== setup.formId) {
+        closeTallyPopup(activeFormId)
+      }
+      activeFormId = setup.formId
       openTallyPopup(setup.formId, {
         ...setup.options,
         onClose: () => {
@@ -32,8 +37,16 @@ export function useTallyRoutes(config: TallyRouteConfig) {
           if (setup.options?.onClose) {
             setup.options.onClose()
           }
+          if (activeFormId === setup.formId) {
+            activeFormId = null
+          }
         },
       })
+    } else {
+      if (activeFormId) {
+        closeTallyPopup(activeFormId)
+        activeFormId = null
+      }
     }
   }
 
@@ -47,4 +60,10 @@ export function useTallyRoutes(config: TallyRouteConfig) {
       handleTallyRoute(newPath)
     }
   )
+
+  onUnmounted(() => {
+    if (activeFormId) {
+      closeTallyPopup(activeFormId)
+    }
+  })
 }

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -33,7 +33,13 @@ const router = createRouter({
     }
 
     // Avoid scroll to top when switching between home, simulateur and calculateur
-    const tallyRoutes = ['/', '/simulateur', '/calculateur']
+    const tallyRoutes = [
+      '/',
+      '/simulateur',
+      '/calculateur',
+      '/demarrer-constatation',
+      '/demarrer-constatation/simulateur',
+    ]
     if (tallyRoutes.includes(to.path) && tallyRoutes.includes(from.path)) {
       return false
     }
@@ -131,6 +137,12 @@ const router = createRouter({
       name: 'ConstatationStart',
       component: () => import('./pages/commencer-constatation.vue'),
       meta: { title: 'Démarrer une constatation' },
+    },
+    {
+      path: '/demarrer-constatation/simulateur',
+      name: 'ConstatationStartSimulateur',
+      component: () => import('./pages/commencer-constatation.vue'),
+      meta: { title: "Simulateur d'éligibilité" },
     },
     {
       path: '/constatation',

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -32,15 +32,10 @@ const router = createRouter({
       return false
     }
 
-    // Avoid scroll to top when switching between home, simulateur and calculateur
-    const tallyRoutes = [
-      '/',
-      '/simulateur',
-      '/calculateur',
-      '/demarrer-constatation',
-      '/demarrer-constatation/simulateur',
-    ]
-    if (tallyRoutes.includes(to.path) && tallyRoutes.includes(from.path)) {
+    // Avoid scroll to top when toggling or switching between Tally modals on the same parent page
+    const isTallyToParent = to.meta.tallyParent === from.path || from.meta.tallyParent === to.path
+    const isTallySameParent = to.meta.tallyParent && to.meta.tallyParent === from.meta.tallyParent
+    if (isTallyToParent || isTallySameParent) {
       return false
     }
 
@@ -61,13 +56,13 @@ const router = createRouter({
       path: '/simulateur',
       name: 'Simulateur',
       component: () => import('./pages/accueil.vue'),
-      meta: { title: "Simulateur d'amende pour dépôt sauvage" },
+      meta: { title: "Simulateur d'amende pour dépôt sauvage", tallyParent: '/' },
     },
     {
       path: '/calculateur',
       name: 'Calculateur',
       component: () => import('./pages/accueil.vue'),
-      meta: { title: 'Calculateur de préjudice' },
+      meta: { title: 'Calculateur de préjudice', tallyParent: '/' },
     },
     {
       path: '/comprendre-la-procedure',
@@ -142,7 +137,7 @@ const router = createRouter({
       path: '/demarrer-constatation/simulateur',
       name: 'ConstatationStartSimulateur',
       component: () => import('./pages/commencer-constatation.vue'),
-      meta: { title: "Simulateur d'éligibilité" },
+      meta: { title: "Simulateur d'éligibilité", tallyParent: '/demarrer-constatation' },
     },
     {
       path: '/constatation',
@@ -176,19 +171,34 @@ const router = createRouter({
       path: '/tableau-de-bord',
       name: 'DashboardBackoffice',
       component: () => import('./pages/backoffice.vue'),
-      meta: { title: 'Backoffice - Tableau de bord', requiresStaff: true, tab: 'dashboard', activeMenu: '/backoffice' },
+      meta: {
+        title: 'Backoffice - Tableau de bord',
+        requiresStaff: true,
+        tab: 'dashboard',
+        activeMenu: '/backoffice',
+      },
     },
     {
       path: '/procedures-liste',
       name: 'ProceduresListBackoffice',
       component: () => import('./pages/backoffice.vue'),
-      meta: { title: 'Backoffice - Liste des procédures', requiresStaff: true, tab: 'list', activeMenu: '/backoffice' },
+      meta: {
+        title: 'Backoffice - Liste des procédures',
+        requiresStaff: true,
+        tab: 'list',
+        activeMenu: '/backoffice',
+      },
     },
     {
       path: '/procedure-detail/:procedureId?',
       name: 'ProcedureDetailBackoffice',
       component: () => import('./pages/backoffice.vue'),
-      meta: { title: 'Backoffice - Détail de la procédure', requiresStaff: true, tab: 'detail', activeMenu: '/backoffice' },
+      meta: {
+        title: 'Backoffice - Détail de la procédure',
+        requiresStaff: true,
+        tab: 'detail',
+        activeMenu: '/backoffice',
+      },
     },
     {
       path: '/mentions-legales',

--- a/frontend/pages/commencer-constatation.vue
+++ b/frontend/pages/commencer-constatation.vue
@@ -22,12 +22,21 @@
               <h2 class="fr-h4">Ce dont vous avez besoin pour commencer la constatation :</h2>
               <ul class="fr-text--sm fr-mb-0 premium-choices-list">
                 <li>
-                  ✅ informations concernant le dépôt sauvage : localisation, volume estimé, types
-                  de déchets, etc.
+                  <span class="fr-icon-checkbox-circle-line fr-text-default--success fr-mr-1w" aria-hidden="true"></span>
+                  <span>Informations concernant le dépôt sauvage : localisation, volume estimé, types de déchets, etc.</span>
                 </li>
-                <li>✅ identité de la personne habilitée qui a constaté les dépôts sauvages</li>
-                <li>✅ Informations sur l'auteur présumé (si connues)</li>
-                <li>⏱️ Temps estimé 7 minutes</li>
+                <li>
+                  <span class="fr-icon-checkbox-circle-line fr-text-default--success fr-mr-1w" aria-hidden="true"></span>
+                  <span>Identité de la personne habilitée qui a constaté les dépôts sauvages</span>
+                </li>
+                <li>
+                  <span class="fr-icon-checkbox-circle-line fr-text-default--success fr-mr-1w" aria-hidden="true"></span>
+                  <span>Informations sur l'auteur présumé (si connues)</span>
+                </li>
+                <li>
+                  <span class="fr-icon-time-line fr-text-default--info fr-mr-1w" aria-hidden="true"></span>
+                  <span>Temps estimé : 7 minutes</span>
+                </li>
               </ul>
             </div>
           </div>
@@ -36,13 +45,17 @@
             <div class="premium-card premium-card--small premium-card--static premium-card--align-left">
               <h2 class="fr-h4">À l'issue de cette étape :</h2>
               <ul class="fr-text--sm fr-mb-0 premium-choices-list">
-                <li>📄 Rapport de constatation généré automatiquement</li>
                 <li>
-                  📄 Lettre d'information prête à être envoyée (si l'auteur présumé est identifié)
+                  <span class="fr-icon-file-text-line fr-text-default--info fr-mr-1w" aria-hidden="true"></span>
+                  <span>Rapport de constatation généré automatiquement</span>
                 </li>
                 <li>
-                  ➡️ Vous serez guidé étape par étape pour faire avancer la procédure adaptée à
-                  votre situation
+                  <span class="fr-icon-file-text-line fr-text-default--info fr-mr-1w" aria-hidden="true"></span>
+                  <span>Lettre d'information prête à être envoyée (si l'auteur présumé est identifié)</span>
+                </li>
+                <li>
+                  <span class="fr-icon-arrow-right-line fr-text-default--info fr-mr-1w" aria-hidden="true"></span>
+                  <span>Vous serez guidé étape par étape pour faire avancer la procédure adaptée à votre situation</span>
                 </li>
               </ul>
             </div>
@@ -51,7 +64,7 @@
 
         <div class="constatation-actions">
           <template v-if="userInfo?.is_authenticated">
-            <div style="text-align: center">
+            <div class="premium-text-center">
               <router-link
                 to="/constatation"
                 class="fr-btn fr-btn--lg"
@@ -130,7 +143,23 @@ onMounted(async () => {
 }
 
 .premium-choices-list {
-  padding-left: 1.5rem;
+  padding-left: 0;
+  list-style-type: none;
+}
+
+.premium-choices-list li {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.premium-choices-list li:last-child {
+  margin-bottom: 0;
+}
+
+.premium-choices-list li span:first-child {
+  flex-shrink: 0;
+  margin-top: 0.125rem;
 }
 
 .constatation-actions {

--- a/frontend/pages/commencer-constatation.vue
+++ b/frontend/pages/commencer-constatation.vue
@@ -9,8 +9,8 @@
         <div class="fr-container">
           <h1 class="fr-h1 fr-mb-3w">Démarrer une procédure dépôt sauvage</h1>
           <p class="fr-text fr-text--lead fr-mb-0">
-            Nous allons vous guider étape par étape. Pour engager une procédure, la première
-            étape consiste à établir le constat du dépôt sauvage.
+            Nous allons vous guider étape par étape. Pour engager une procédure, la première étape
+            consiste à établir le constat du dépôt sauvage.
           </p>
         </div>
       </div>
@@ -18,12 +18,9 @@
       <div class="fr-container fr-pb-8w">
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-12 fr-col-md-6">
-            <div
-              class="premium-card premium-card--small premium-card--static"
-              style="align-items: flex-start; text-align: left"
-            >
+            <div class="premium-card premium-card--small premium-card--static premium-card--align-left">
               <h2 class="fr-h4">Ce dont vous avez besoin pour commencer la constatation :</h2>
-              <ul class="fr-text--sm fr-mb-0 premium-choices-list" style="padding-left: 1.5rem">
+              <ul class="fr-text--sm fr-mb-0 premium-choices-list">
                 <li>
                   ✅ informations concernant le dépôt sauvage : localisation, volume estimé, types
                   de déchets, etc.
@@ -36,12 +33,9 @@
           </div>
 
           <div class="fr-col-12 fr-col-md-6">
-            <div
-              class="premium-card premium-card--small premium-card--static"
-              style="align-items: flex-start; text-align: left"
-            >
+            <div class="premium-card premium-card--small premium-card--static premium-card--align-left">
               <h2 class="fr-h4">À l'issue de cette étape :</h2>
-              <ul class="fr-text--sm fr-mb-0 premium-choices-list" style="padding-left: 1.5rem">
+              <ul class="fr-text--sm fr-mb-0 premium-choices-list">
                 <li>📄 Rapport de constatation généré automatiquement</li>
                 <li>
                   📄 Lettre d'information prête à être envoyée (si l'auteur présumé est identifié)
@@ -130,23 +124,13 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.text-blue {
-  color: var(--text-active-blue-france);
+.premium-card--align-left {
+  align-items: flex-start;
+  text-align: left;
 }
 
-.font-premium {
-  font-weight: 700;
-  color: var(--text-title-blue-france);
-}
-
-.text-muted {
-  color: var(--text-mention-grey);
-}
-
-@media (min-width: 768px) {
-  .text-md-right {
-    text-align: right;
-  }
+.premium-choices-list {
+  padding-left: 1.5rem;
 }
 
 .constatation-actions {

--- a/frontend/pages/commencer-constatation.vue
+++ b/frontend/pages/commencer-constatation.vue
@@ -7,51 +7,30 @@
     <div v-else>
       <div class="fr-background-alt--blue-france fr-mb-6w fr-py-6w">
         <div class="fr-container">
-          <h1 class="fr-h1 fr-mb-3w">Lancer une procédure</h1>
+          <h1 class="fr-h1 fr-mb-3w">Démarrer une procédure dépôt sauvage</h1>
           <p class="fr-text fr-text--lead fr-mb-0">
-            Pour initier une procédure, vous devez commencer par établir le constat du dépôt
-            sauvage.
+            Nous allons vous guider étape par étape. Pour engager une procédure, la première
+            étape consiste à établir le constat du dépôt sauvage.
           </p>
         </div>
       </div>
 
       <div class="fr-container fr-pb-8w">
-        <PremiumCallout
-          v-if="dossiersCount > 0"
-          type="banner"
-          title="Vous avez déjà des procédures en cours"
-          :description="`Vous avez actuellement <strong>${dossiersCount} procédure${dossiersCount > 1 ? 's' : ''} en cours</strong>.`"
-          iconClass="fr-icon-folder-2-line"
-          buttonText="Voir mes procédures en cours"
-          buttonTo="/mes-procedures"
-        >
-          <template #button-icon>
-            <span class="fr-icon-eye-line fr-mr-1w" aria-hidden="true"></span>
-          </template>
-        </PremiumCallout>
-
-        <PremiumCallout
-          description="Avant de démarrer votre constatation, vous pouvez vérifier votre éligibilité à la procédure administrative."
-          iconClass="fr-icon-question-line"
-          buttonText="Je vérifie mon éligibilité grâce au simulateur"
-          @click="openSimulator"
-        />
-
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-12 fr-col-md-6">
             <div
               class="premium-card premium-card--small premium-card--static"
               style="align-items: flex-start; text-align: left"
             >
-              <h2 class="fr-h4">De quoi avez-vous besoin pour réaliser cette constatation ?</h2>
+              <h2 class="fr-h4">Ce dont vous avez besoin pour commencer la constatation :</h2>
               <ul class="fr-text--sm fr-mb-0 premium-choices-list" style="padding-left: 1.5rem">
                 <li>
-                  Les informations concernant le dépôt sauvage : localisation, descriptions du
-                  dépôt, volumes, types de déchets, etc.
+                  ✅ informations concernant le dépôt sauvage : localisation, volume estimé, types
+                  de déchets, etc.
                 </li>
-                <li>L'identité de la personne habilitée qui a constaté les dépôts sauvages</li>
-                <li>Les informations éventuelles sur le responsable présumé</li>
-                <li>Cette démarche nécessite une authentification via ProConnect.</li>
+                <li>✅ identité de la personne habilitée qui a constaté les dépôts sauvages</li>
+                <li>✅ Informations sur l'auteur présumé (si connues)</li>
+                <li>⏱️ Temps estimé 7 minutes</li>
               </ul>
             </div>
           </div>
@@ -61,57 +40,83 @@
               class="premium-card premium-card--small premium-card--static"
               style="align-items: flex-start; text-align: left"
             >
-              <h2 class="fr-h4">À l'issue de la constatation :</h2>
+              <h2 class="fr-h4">À l'issue de cette étape :</h2>
               <ul class="fr-text--sm fr-mb-0 premium-choices-list" style="padding-left: 1.5rem">
+                <li>📄 Rapport de constatation généré automatiquement</li>
                 <li>
-                  Vous pourrez récupérer les documents personnalisés utiles pour votre procédure
+                  📄 Lettre d'information prête à être envoyée (si l'auteur présumé est identifié)
                 </li>
                 <li>
-                  Vous serez guidé étape par étape pour vous permettre d'initier la procédure
-                  adaptée à votre situation
+                  ➡️ Vous serez guidé étape par étape pour faire avancer la procédure adaptée à
+                  votre situation
                 </li>
               </ul>
             </div>
           </div>
         </div>
 
-        <div v-if="userInfo?.is_authenticated" class="fr-mt-6w" style="text-align: center">
-          <router-link
-            to="/constatation"
-            class="fr-btn fr-btn--lg"
-            title="Démarrer la constatation"
-          >
-            Démarrer la constatation
-          </router-link>
-        </div>
+        <div class="constatation-actions">
+          <template v-if="userInfo?.is_authenticated">
+            <div style="text-align: center">
+              <router-link
+                to="/constatation"
+                class="fr-btn fr-btn--lg"
+                title="Démarrer la constatation"
+              >
+                Démarrer la constatation
+              </router-link>
+            </div>
 
-        <LoginInvitation
-          v-else
-          title="Connectez-vous pour démarrer"
-          description="Pour initier une procédure et accéder au formulaire de constatation de dépôt sauvage, vous devez vous connecter avec ProConnect."
-          redirectTo="/constatation"
-        />
+            <PremiumCallout
+              type="banner"
+              title="Vous avez un doute ?"
+              description="Vous ne savez pas si votre situation permet d'engager une procédure ?"
+              iconClass="fr-icon-question-line"
+              buttonText="Vérifier ma situation en 2 min"
+              buttonTo="/demarrer-constatation/simulateur"
+            />
+          </template>
+
+          <template v-else>
+            <PremiumCallout
+              type="banner"
+              title="Vous avez un doute ?"
+              description="Vous ne savez pas si votre situation permet d'engager une procédure ?"
+              iconClass="fr-icon-question-line"
+              buttonText="Vérifier ma situation en 2 min"
+              buttonTo="/demarrer-constatation/simulateur"
+            />
+
+            <LoginInvitation
+              title="Connectez-vous pour démarrer la constatation"
+              description="Pour initier une procédure et accéder au formulaire de constatation de dépôt sauvage, vous devez vous connecter avec ProConnect."
+              redirectTo="/constatation"
+            />
+          </template>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import LoginInvitation from '../components/shared/LoginInvitation.vue'
 import PageLoader from '../components/shared/PageLoader.vue'
 import PremiumCallout from '../components/shared/PremiumCallout.vue'
+import { useTallyRoutes } from '../composables/useTally'
 import { getUserInfo, type UserInfo } from '../services/api'
-import { openTallyPopup } from '../utils/tally'
 
 const userInfo = ref<UserInfo | null>(null)
 const showLoading = ref(true)
 
-const dossiersCount = computed(() => userInfo.value?.procedures_count || 0)
-
-const openSimulator = () => {
-  openTallyPopup('A7xA8z', { layout: 'modal', width: 900 })
-}
+useTallyRoutes({
+  '/demarrer-constatation/simulateur': {
+    formId: 'A7xA8z',
+    options: { layout: 'modal', width: 900 },
+    returnPath: '/demarrer-constatation',
+  },
+})
 
 onMounted(async () => {
   try {
@@ -142,5 +147,20 @@ onMounted(async () => {
   .text-md-right {
     text-align: right;
   }
+}
+
+.constatation-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  margin-top: 3rem;
+}
+
+.constatation-actions :deep(.premium-alert-banner) {
+  margin: 0 !important;
+}
+
+.constatation-actions :deep(.premium-block-container) {
+  padding-top: 0 !important;
 }
 </style>


### PR DESCRIPTION
## Résumé
- Titre et texte d'intro clarifiés
- Suppression du bandeau "procédures en cours" qui interrompait le parcours (accessible via "Mes procédures")
- Blocs "besoin" / "à l'issue" simplifiés avec icônes et temps estimé (7 min)
- Le simulateur d'éligibilité devient un bandeau "Vous avez un doute ?" en bas de page (au lieu d'un bandeau bloquant en haut), avec sa propre URL comme sur les autres pages Tally
- Pour les non-connectés, le simulateur passe avant l'invitation à se connecter (action secondaire)
- Espacement harmonisé entre les blocs de fin de page

## Test
Vérifié en local (connecté et non connecté) : textes, ordre des blocs, ouverture/fermeture de la popup simulateur, espacements.