### PR TITLE
Corrections orthographiques : webinaire et clarification page comment agir

### DIFF
--- a/frontend/pages/comment-agir.vue
+++ b/frontend/pages/comment-agir.vue
@@ -5,7 +5,7 @@
         <h1 class="fr-h1 fr-mb-3w">Comment agir contre les dépôts sauvages ?</h1>
         <p class="fr-text fr-text--lead">
           Les maires et les présidents d'intercommunalité disposent d'un levier efficace pour agir
-          contre les dépôts sauvages. Grâce à la procédure administrative, ils peuvent obtenir le
+          contre les dépôts sauvages : la procédure administrative. Ils peuvent ainsi obtenir le
           nettoyage d'un dépôt ou sanctionner son auteur lorsqu'il est identifié.
         </p>
 
@@ -43,7 +43,7 @@
             <span>
               comment aller plus loin grâce à notre webinaire d'accompagnement (
               <router-link to="/rdv" class="fr-link"
-                >Je m'inscris au prochain wébinaire</router-link
+                >Je m'inscris au prochain webinaire</router-link
               >
               )
             </span>

--- a/frontend/pages/rdv.vue
+++ b/frontend/pages/rdv.vue
@@ -13,7 +13,7 @@
           rel="noopener noreferrer"
           class="fr-btn fr-btn--lg fr-icon-video-chat-line fr-btn--icon-left"
         >
-          Je m'inscris au wébinaire via RDV service public
+          Je m'inscris au webinaire via RDV service public
         </a>
       </div>
     </div>
@@ -56,7 +56,7 @@
       <hr class="fr-my-4w" />
 
       <section class="fr-mb-4w">
-        <h2 class="fr-h4 fr-mb-3w">À qui s'adresse ce wébinaire</h2>
+        <h2 class="fr-h4 fr-mb-3w">À qui s'adresse ce webinaire</h2>
         <ul class="fr-raw-list fr-mb-0">
           <li class="fr-mb-1w fr-display-flex">
             <span class="fr-icon-user-line fr-text-default--info fr-mr-1w" aria-hidden="true"></span>
@@ -116,7 +116,7 @@
           rel="noopener noreferrer"
           class="fr-btn fr-btn--lg fr-icon-video-chat-line fr-btn--icon-left"
         >
-          Je m'inscris au wébinaire via RDV service public
+          Je m'inscris au webinaire via RDV service public
         </a>
       </div>
 


### PR DESCRIPTION
## Résumé
- Uniformisation de l'orthographe de « webinaire » (suppression de l'accent erroné « wébinaire ») sur les pages rdv et comment-agir
- Reformulation de la phrase d'introduction de la page « Comment agir » pour plus de clarté

## Test plan
- Vérifié en local que le texte s'affiche correctement

🤖 Generated with Claude Code