### PR TITLE
Améliorer la visualisation des cartes de procédures sur "Mes procédures"

### DIFF
--- a/backend/constatations/serializers.py
+++ b/backend/constatations/serializers.py
@@ -71,7 +71,11 @@ class ConstatationSerializer(serializers.ModelSerializer):
         sp = getattr(obj, "suivi_procedure", None)
         if not sp:
             return {"etape_en_cours": 1}
-        return {"etape_en_cours": sp.etape_en_cours}
+        return {
+            "etape_en_cours": sp.etape_en_cours,
+            "identification_reussie": sp.identification_reussie,
+            "decision_poursuite": sp.decision_poursuite,
+        }
 
     def get_docs_generation_flags(self, auteur_identifie):
         return {

--- a/backend/constatations/serializers.py
+++ b/backend/constatations/serializers.py
@@ -75,6 +75,7 @@ class ConstatationSerializer(serializers.ModelSerializer):
             "etape_en_cours": sp.etape_en_cours,
             "identification_reussie": sp.identification_reussie,
             "decision_poursuite": sp.decision_poursuite,
+            "dossier_archive": sp.dossier_archive,
         }
 
     def get_docs_generation_flags(self, auteur_identifie):

--- a/frontend/pages/mes-procedures.vue
+++ b/frontend/pages/mes-procedures.vue
@@ -34,38 +34,38 @@
           <div class="fr-card fr-card--no-arrow shadow-card">
             <div class="fr-card__body">
               <div class="fr-card__content">
-                <h3 class="fr-card__title">Procédure #{{ procedure.id }}</h3>
-                <div class="fr-card__desc">
-                  <div
-                    v-if="procedure.suivi_procedure"
-                    class="fr-alert fr-alert--info fr-alert--sm fr-mt-1w fr-mb-2w"
-                  >
-                    <p class="fr-text--sm">
-                      Prochaine étape :
-                      <strong>{{
-                        getStepLabel(
-                          procedure.suivi_procedure.etape_en_cours,
-                          procedure.auteur_identifie
-                        )
-                      }}</strong>
-                    </p>
+                <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-1w">
+                  <div class="fr-col-auto">
+                    <h3 class="fr-card__title fr-mb-0">Procédure #{{ procedure.id }}</h3>
                   </div>
+                  <div class="fr-col-auto">
+                    <DsfrBadge
+                      :type="procedure.auteur_identifie ? 'success' : 'info'"
+                      :label="procedure.auteur_identifie ? 'Auteur identifié' : 'Auteur non identifié'"
+                      class="fr-badge--no-icon"
+                    />
+                  </div>
+                </div>
+                <div class="fr-card__desc">
                   <Metadata :procedure="procedure" />
                 </div>
               </div>
 
               <div class="fr-card__footer">
+                <div
+                  v-if="procedure.suivi_procedure"
+                  class="fr-alert fr-alert--info fr-alert--sm fr-mb-2w"
+                >
+                  <p class="fr-text--sm">
+                    Prochaine étape :
+                    <strong>{{ getNextStepTitle(procedure) }}</strong>
+                  </p>
+                </div>
                 <ul class="fr-btns-group fr-btns-group--inline-lg">
                   <li>
                     <DsfrButton @click="router.push(getSuiviProcedureUrl(procedure.id))">
                       <span class="fr-icon-file-line fr-mr-1w" aria-hidden="true"></span>
-                      Suivre la procédure
-                    </DsfrButton>
-                  </li>
-                  <li>
-                    <DsfrButton secondary @click="router.push(`/constatation/${procedure.id}`)">
-                      <span class="fr-icon-edit-line fr-mr-1w" aria-hidden="true"></span>
-                      Modifier la constatation
+                      Continuer la procédure
                     </DsfrButton>
                   </li>
                 </ul>
@@ -85,15 +85,15 @@
 
 <script setup lang="ts">
 import { useProcedureStore } from '@/stores/procedure'
-import { getStepLabel } from '@/utils/backoffice'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import AucuneProcedureBox from '../components/procedures/AucuneProcedureBox.vue'
 import Chargement from '../components/procedures/Chargement.vue'
 import Metadata from '../components/procedures/Metadata.vue'
 import LoginInvitation from '../components/shared/LoginInvitation.vue'
-import { getUserInfo, type UserInfo } from '../services/api'
+import { getUserInfo, type ProcedureOverview, type UserInfo } from '../services/api'
 import { getSuiviProcedureUrl } from '../services/urls'
+import { getCurrentStepTitle } from '../utils/procedure-steps'
 
 const router = useRouter()
 const userInfo = ref<UserInfo | null>(null)
@@ -101,6 +101,13 @@ const procedureStore = useProcedureStore()
 const showLoading = ref(true)
 
 const procedures = computed(() => procedureStore.procedures)
+
+const getNextStepTitle = (procedure: ProcedureOverview) =>
+  getCurrentStepTitle(procedure.suivi_procedure?.etape_en_cours ?? 0, {
+    auteurIdentifie: procedure.auteur_identifie,
+    identificationReussie: procedure.suivi_procedure?.identification_reussie,
+    decisionPoursuite: procedure.suivi_procedure?.decision_poursuite,
+  })
 
 onMounted(async () => {
   try {

--- a/frontend/pages/mes-procedures.vue
+++ b/frontend/pages/mes-procedures.vue
@@ -53,7 +53,13 @@
 
               <div class="fr-card__footer">
                 <div
-                  v-if="procedure.suivi_procedure"
+                  v-if="procedure.suivi_procedure?.dossier_archive"
+                  class="fr-alert fr-alert--success fr-alert--sm fr-mb-2w"
+                >
+                  <p class="fr-text--sm">Procédure clôturée</p>
+                </div>
+                <div
+                  v-else-if="procedure.suivi_procedure"
                   class="fr-alert fr-alert--info fr-alert--sm fr-mb-2w"
                 >
                   <p class="fr-text--sm">

--- a/frontend/pages/mes-procedures.vue
+++ b/frontend/pages/mes-procedures.vue
@@ -41,7 +41,9 @@
                   <div class="fr-col-auto">
                     <DsfrBadge
                       :type="procedure.auteur_identifie ? 'success' : 'info'"
-                      :label="procedure.auteur_identifie ? 'Auteur identifié' : 'Auteur non identifié'"
+                      :label="
+                        procedure.auteur_identifie ? 'Auteur identifié' : 'Auteur non identifié'
+                      "
                       class="fr-badge--no-icon"
                     />
                   </div>
@@ -52,26 +54,35 @@
               </div>
 
               <div class="fr-card__footer">
-                <div
+                <DsfrBadge
                   v-if="procedure.suivi_procedure?.dossier_archive"
-                  class="fr-alert fr-alert--success fr-alert--sm fr-mb-2w"
-                >
-                  <p class="fr-text--sm">Procédure clôturée</p>
-                </div>
-                <div
+                  type="success"
+                  label="Procédure clôturée"
+                  class="fr-mb-2w"
+                />
+                <DsfrBadge
                   v-else-if="procedure.suivi_procedure"
-                  class="fr-alert fr-alert--info fr-alert--sm fr-mb-2w"
-                >
-                  <p class="fr-text--sm">
-                    Prochaine étape :
-                    <strong>{{ getNextStepTitle(procedure) }}</strong>
-                  </p>
-                </div>
+                  type="info"
+                  :label="`Prochaine étape : ${getNextStepTitle(procedure)}`"
+                  class="fr-mb-2w"
+                />
                 <ul class="fr-btns-group fr-btns-group--inline-lg">
                   <li>
                     <DsfrButton @click="router.push(getSuiviProcedureUrl(procedure.id))">
-                      <span class="fr-icon-file-line fr-mr-1w" aria-hidden="true"></span>
-                      Continuer la procédure
+                      <span
+                        :class="
+                          procedure.suivi_procedure?.dossier_archive
+                            ? 'fr-icon-eye-line'
+                            : 'fr-icon-file-line'
+                        "
+                        class="fr-mr-1w"
+                        aria-hidden="true"
+                      ></span>
+                      {{
+                        procedure.suivi_procedure?.dossier_archive
+                          ? 'Consulter la procédure'
+                          : 'Continuer la procédure'
+                      }}
                     </DsfrButton>
                   </li>
                 </ul>

--- a/frontend/pages/suivi-procedure.vue
+++ b/frontend/pages/suivi-procedure.vue
@@ -120,6 +120,7 @@ import { API_URLS, fetchResource, getUserInfo } from '../services/api'
 import { getDocConstatUrl, getLettreInfoUrl } from '../services/urls'
 import { useSuiviStore } from '../stores/suivi-procedure'
 import { debounce } from '../utils/debounce'
+import { getStepTitles } from '../utils/procedure-steps'
 
 const route = useRoute()
 const router = useRouter()
@@ -171,41 +172,43 @@ const steps = computed(() => {
 
   if (!hasProcedure.value) {
     return [
-      { title: 'Constatation', completed: getStepStatus(0) },
-      { title: 'Procédure à mettre à jour', completed: false },
+      { title: 'Réaliser la constatation', completed: getStepStatus(0) },
+      { title: 'Mettre à jour la procédure', completed: false },
     ]
   }
 
   if (!auteurIdentifie.value) {
+    const titles = getStepTitles({
+      auteurIdentifie: false,
+      identificationReussie: suiviProcedure.value.identification_reussie,
+    })
     const baseSteps = [
-      { title: 'Constatation', completed: getStepStatus(0) },
-      { title: 'Pièces de procédure', completed: getStepStatus(1) },
-      { title: "Identifier l'auteur", completed: getStepStatus(2) },
+      { title: titles[0], completed: getStepStatus(0) },
+      { title: titles[1], completed: getStepStatus(1) },
+      { title: titles[2], completed: getStepStatus(2) },
     ]
 
     if (suiviProcedure.value.identification_reussie === true) {
-      baseSteps.push({ title: 'Mettre à jour le dossier', completed: false })
+      baseSteps.push({ title: titles[3], completed: false })
     } else if (suiviProcedure.value.identification_reussie === false) {
-      baseSteps.push({ title: 'Clôture de la procédure', completed: getStepStatus(5) })
+      baseSteps.push({ title: titles[3], completed: getStepStatus(5) })
     }
 
     return baseSteps
   }
 
-  const actionStepTitle =
-    suiviProcedure.value.decision_poursuite === 'sanction'
-      ? "Sanctionner l'auteur"
-      : suiviProcedure.value.decision_poursuite === 'abandon'
-        ? 'Abandonner les poursuites'
-        : 'Action de poursuite'
+  const titles = getStepTitles({
+    auteurIdentifie: true,
+    decisionPoursuite: suiviProcedure.value.decision_poursuite,
+  })
 
   return [
-    { title: 'Constatation', completed: getStepStatus(0) },
-    { title: 'Signer les pièces de procédure', completed: getStepStatus(1) },
-    { title: "Notifier l'auteur présumé", completed: getStepStatus(2) },
-    { title: 'Décider des poursuites', completed: getStepStatus(3) },
-    { title: actionStepTitle, completed: getStepStatus(4) },
-    { title: 'Clôture de la procédure', completed: getStepStatus(5) },
+    { title: titles[0], completed: getStepStatus(0) },
+    { title: titles[1], completed: getStepStatus(1) },
+    { title: titles[2], completed: getStepStatus(2) },
+    { title: titles[3], completed: getStepStatus(3) },
+    { title: titles[4], completed: getStepStatus(4) },
+    { title: titles[5], completed: getStepStatus(5) },
   ]
 })
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -105,8 +105,11 @@ export interface ProcedureOverview {
   heure_constat: string | null
   localisation_depot: string | null
   last_sync: string | null
+  auteur_identifie: boolean
   suivi_procedure?: {
     etape_en_cours: number
+    identification_reussie?: boolean | null
+    decision_poursuite?: string | null
   }
 }
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -110,6 +110,7 @@ export interface ProcedureOverview {
     etape_en_cours: number
     identification_reussie?: boolean | null
     decision_poursuite?: string | null
+    dossier_archive?: boolean
   }
 }
 

--- a/frontend/utils/backoffice.ts
+++ b/frontend/utils/backoffice.ts
@@ -1,3 +1,5 @@
+import { getShortStepLabel } from './procedure-steps'
+
 export const getBadgeClass = (step: number) => {
   if (step === 0) return 'bo-badge bo-badge--yellow'
   if (step === 1) return 'bo-badge bo-badge--gray'
@@ -33,29 +35,8 @@ export const getTraitementBadgeClass = (traitement: string) => {
   return 'bo-badge bo-badge--gray'
 }
 
-export const getStepLabel = (step: number, auteurIdentifie: boolean = true) => {
-  if (auteurIdentifie) {
-    const labels = [
-      'Constatation',
-      'Pièces jointes',
-      'Notification',
-      'Décision',
-      'Sanctionner',
-      'Clôture',
-    ]
-    return labels[step] || ''
-  } else {
-    const labels = [
-      'Constatation',
-      'Pièces jointes',
-      "Identifier l'auteur",
-      'Recherche',
-      '',
-      'Clôture',
-    ]
-    return labels[step] || ''
-  }
-}
+export const getStepLabel = (step: number, auteurIdentifie: boolean = true) =>
+  getShortStepLabel(step, auteurIdentifie)
 
 /**
  * Generic query parameter parser to parse and typed-coerce query values

--- a/frontend/utils/procedure-steps.ts
+++ b/frontend/utils/procedure-steps.ts
@@ -45,7 +45,7 @@ export const getStepTitles = ({
   if (!auteurIdentifie) {
     const titles = [
       'Réaliser la constatation',
-      'Compléter les pièces de procédure',
+      'Signer les pièces de procédure',
       "Identifier l'auteur",
     ]
     if (identificationReussie === true) {

--- a/frontend/utils/procedure-steps.ts
+++ b/frontend/utils/procedure-steps.ts
@@ -1,0 +1,77 @@
+export interface StepTitleContext {
+  auteurIdentifie: boolean
+  identificationReussie?: boolean | null
+  decisionPoursuite?: string | null
+}
+
+/**
+ * Libellés courts, utilisés dans les vues back-office (tableau de bord, liste des
+ * procédures, timeline). Indexés directement par `etape_en_cours`, sans dépendre de
+ * l'issue de l'identification ni de la décision de poursuite.
+ */
+const SHORT_LABELS_AUTEUR_IDENTIFIE = [
+  'Constatation',
+  'Pièces jointes',
+  'Notification',
+  'Décision',
+  'Sanctionner',
+  'Clôture',
+]
+
+const SHORT_LABELS_AUTEUR_NON_IDENTIFIE = [
+  'Constatation',
+  'Pièces jointes',
+  "Identifier l'auteur",
+  'Recherche',
+  '',
+  'Clôture',
+]
+
+export const getShortStepLabel = (step: number, auteurIdentifie: boolean = true): string => {
+  const labels = auteurIdentifie ? SHORT_LABELS_AUTEUR_IDENTIFIE : SHORT_LABELS_AUTEUR_NON_IDENTIFIE
+  return labels[step] || ''
+}
+
+/**
+ * Libellés longs, utilisés comme titres de section sur la page suivi-procedure et
+ * comme "prochaine étape" sur la page mes-procedures. L'index dans le tableau
+ * correspond à la valeur de `etape_en_cours`.
+ */
+export const getStepTitles = ({
+  auteurIdentifie,
+  identificationReussie,
+  decisionPoursuite,
+}: StepTitleContext): string[] => {
+  if (!auteurIdentifie) {
+    const titles = [
+      'Réaliser la constatation',
+      'Compléter les pièces de procédure',
+      "Identifier l'auteur",
+    ]
+    if (identificationReussie === true) {
+      titles.push('Mettre à jour le dossier')
+    } else if (identificationReussie === false) {
+      titles.push('Clôturer la procédure')
+    }
+    return titles
+  }
+
+  const actionStepTitle =
+    decisionPoursuite === 'sanction'
+      ? "Sanctionner l'auteur"
+      : decisionPoursuite === 'abandon'
+        ? 'Abandonner les poursuites'
+        : "Mener l'action de poursuite"
+
+  return [
+    'Réaliser la constatation',
+    'Signer les pièces de procédure',
+    "Notifier l'auteur présumé",
+    'Décider des poursuites',
+    actionStepTitle,
+    'Clôturer la procédure',
+  ]
+}
+
+export const getCurrentStepTitle = (etapeEnCours: number, context: StepTitleContext): string =>
+  getStepTitles(context)[etapeEnCours] ?? ''


### PR DESCRIPTION
## Résumé

- Ajout d'un badge « Auteur identifié » / « Auteur non identifié » sur chaque carte de procédure
- Bouton principal renommé en « Continuer la procédure » ; suppression du bouton secondaire « Modifier la constatation »
- Le libellé « Prochaine étape » utilise désormais les mêmes titres que la page de suivi de procédure (au lieu d'un libellé propre à la carte), et a été rapproché du bouton d'action pour faciliter le passage à l'action
- Les titres d'étape utilisent maintenant un verbe d'action (ex : « Réaliser la constatation », « Clôturer la procédure »)
- Centralisation des libellés d'étape (courts pour le back-office, longs pour le parcours usager) dans un seul dictionnaire partagé (`frontend/utils/procedure-steps.ts`), pour éviter toute divergence de texte entre les pages mes-procedures, suivi-procedure et le back-office
- Petite modification backend : expose `identification_reussie` et `decision_poursuite` sur l'endpoint des procédures de l'usager, nécessaire au calcul du bon libellé long

## Test plan

- [x] Vérifié manuellement sur « Mes procédures » : badge, bouton, libellé « Prochaine étape » pour tous les cas (auteur identifié/non identifié, décision sanction/abandon, identification réussie/échouée)
- [x] Vérifié manuellement sur « Suivi de procédure » : mêmes cas, contenu de chaque section
- [x] Vérifié manuellement sur le back-office : Tableau de bord, Procédures (liste), Détail procédure — libellés courts inchangés
