### PR TITLE
Ajouter un formulaire d'utilisabilité en fin de constatation

### DIFF
--- a/frontend/components/forms/constatation/ConstatationSuccess.vue
+++ b/frontend/components/forms/constatation/ConstatationSuccess.vue
@@ -24,16 +24,20 @@
       <router-link v-if="constatationId" :to="`/constatation/${constatationId}`" class="fr-link">
         Modifier la constatation
       </router-link>
+
+      <TallySurveyEmbed v-if="constatationId && commune" :commune="commune" :id-dossier="constatationId" />
     </template>
   </PremiumBox>
 </template>
 
 <script setup lang="ts">
 import PremiumBox from '@/components/shared/PremiumBox.vue'
+import TallySurveyEmbed from '@/components/shared/TallySurveyEmbed.vue'
 import { DsfrButton, DsfrCallout } from '@gouvminint/vue-dsfr'
 
 defineProps<{
   constatationId?: number | null
+  commune?: string | null
 }>()
 
 defineEmits<{

--- a/frontend/components/forms/constatation/ConstatationSuccess.vue
+++ b/frontend/components/forms/constatation/ConstatationSuccess.vue
@@ -1,23 +1,19 @@
 <template>
   <PremiumBox
     title="Constatation enregistrée !"
-    description="La constatation du dépôt sauvage a bien été enregistrée. Vous pouvez maintenant accéder au suivi de procédure pour consulter les prochaines étapes."
+    description="Vos documents de procédure ont été pré-remplis automatiquement. Vous pouvez passer aux prochaines étapes."
     iconClass="fr-icon-checkbox-circle-fill"
     iconColor="#00875a"
   >
-    <DsfrCallout
-      title="Attention la procédure n'est pas terminée !"
-      class="fr-mb-4w fr-callout--yellow-tournesol"
-      style="text-align: left;"
-    >
-      <p>
-        Le rapport de constatation généré devra être signé par l'autorité compétente pour avoir une
-        valeur juridique.
+    <DsfrAlert type="info" small class="fr-mb-4w" style="text-align: left;">
+      <p class="fr-mb-0">
+        Le(s) document(s) doivent être signés par la personne habilitée pour avoir une valeur
+        juridique.
       </p>
-    </DsfrCallout>
+    </DsfrAlert>
 
     <template #actions>
-      <DsfrButton label="Consulter les prochaines étapes sur mon suivi de procédure" @click="$emit('goToSuivi')" />
+      <DsfrButton label="Accéder aux documents sur mon suivi de procédure" @click="$emit('goToSuivi')" />
     </template>
 
     <template #footer>
@@ -33,7 +29,7 @@
 <script setup lang="ts">
 import PremiumBox from '@/components/shared/PremiumBox.vue'
 import TallySurveyEmbed from '@/components/shared/TallySurveyEmbed.vue'
-import { DsfrButton, DsfrCallout } from '@gouvminint/vue-dsfr'
+import { DsfrAlert, DsfrButton } from '@gouvminint/vue-dsfr'
 
 defineProps<{
   constatationId?: number | null

--- a/frontend/components/forms/constatation/ConstatationSuccess.vue
+++ b/frontend/components/forms/constatation/ConstatationSuccess.vue
@@ -5,15 +5,18 @@
     iconClass="fr-icon-checkbox-circle-fill"
     iconColor="#00875a"
   >
-    <DsfrAlert type="info" small class="fr-mb-4w" style="text-align: left;">
+    <DsfrAlert type="info" small class="fr-mb-4w" style="text-align: left">
       <p class="fr-mb-0">
-        Le(s) document(s) doivent être signés par la personne habilitée pour avoir une valeur
+        Le(s) document(s) doivent être signé(s) par la personne habilitée pour avoir une valeur
         juridique.
       </p>
     </DsfrAlert>
 
     <template #actions>
-      <DsfrButton label="Accéder aux documents sur mon suivi de procédure" @click="$emit('goToSuivi')" />
+      <DsfrButton
+        label="Accéder aux documents sur mon suivi de procédure"
+        @click="$emit('goToSuivi')"
+      />
     </template>
 
     <template #footer>
@@ -21,7 +24,11 @@
         Modifier la constatation
       </router-link>
 
-      <TallySurveyEmbed v-if="constatationId && commune" :commune="commune" :id-dossier="constatationId" />
+      <TallySurveyEmbed
+        v-if="constatationId && commune"
+        :commune="commune"
+        :id-dossier="constatationId"
+      />
     </template>
   </PremiumBox>
 </template>

--- a/frontend/components/shared/TallySurveyEmbed.vue
+++ b/frontend/components/shared/TallySurveyEmbed.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="fr-mt-4w fr-mb-4w" style="text-align: left;">
+    <p class="fr-text--sm fr-mb-1w fr-text-mention--grey" style="text-align: center;">
+      <span class="fr-icon-chat-3-line fr-mr-1w" aria-hidden="true"></span>
+      Donnez votre avis en 10 secondes
+    </p>
+    <iframe
+      :data-tally-src="tallySrc"
+      loading="lazy"
+      width="100%"
+      height="180"
+      frameborder="0"
+      marginheight="0"
+      marginwidth="0"
+      title="Questionnaire de satisfaction"
+    ></iframe>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { loadTallyEmbeds } from '@/utils/tally'
+
+const props = defineProps<{
+  commune: string
+  idDossier: number | string
+}>()
+
+const tallySrc = computed(() => {
+  const params = new URLSearchParams({
+    alignLeft: '1',
+    hideTitle: '1',
+    transparentBackground: '1',
+    dynamicHeight: '1',
+  })
+  params.set('commune', props.commune)
+  params.set('ID_dossier', String(props.idDossier))
+
+  return `https://tally.so/embed/VLArqN?${params.toString()}`
+})
+
+onMounted(() => {
+  loadTallyEmbeds()
+})
+</script>

--- a/frontend/pages/constatation-fin.vue
+++ b/frontend/pages/constatation-fin.vue
@@ -5,6 +5,7 @@
     <ConstatationSuccess
       v-else-if="userInfo?.is_authenticated"
       :constatation-id="constatationId"
+      :commune="commune"
       @go-to-suivi="router.push(`/suivi-procedure/${constatationId}`)"
       @go-to-procedures="router.push('/mes-procedures')"
     />
@@ -24,12 +25,13 @@ import { useRouter } from 'vue-router'
 import ConstatationSuccess from '../components/forms/constatation/ConstatationSuccess.vue'
 import LoginInvitation from '../components/shared/LoginInvitation.vue'
 import PageLoader from '../components/shared/PageLoader.vue'
-import { getUserInfo, type UserInfo } from '../services/api'
+import { API_URLS, fetchResource, getUserInfo, type UserInfo } from '../services/api'
 
 const router = useRouter()
 const userInfo = ref<UserInfo | null>(null)
 const showLoading = ref(true)
 const constatationId = ref<number | null>(null)
+const commune = ref<string | null>(null)
 
 onMounted(async () => {
   try {
@@ -39,6 +41,15 @@ onMounted(async () => {
       const id = parseInt(idParam as string, 10)
       if (!isNaN(id)) {
         constatationId.value = id
+
+        if (userInfo.value.is_authenticated) {
+          try {
+            const constatation = await fetchResource(`${API_URLS.constatations}${id}/`)
+            commune.value = constatation.commune ?? null
+          } catch (error) {
+            console.error('Failed to load constatation:', error)
+          }
+        }
       }
     }
   } catch (error) {

--- a/frontend/tests/constatation-success.test.ts
+++ b/frontend/tests/constatation-success.test.ts
@@ -15,7 +15,7 @@ describe('ConstatationSuccess.vue', () => {
             template: `<button @click="$emit('click')"><slot /><span class="label">{{ label }}</span></button>`,
             props: ['label'],
           },
-          DsfrCallout: true,
+          DsfrAlert: true,
           RouterLink: {
             props: ['to'],
             template: `<a :href="to"><slot /></a>`,
@@ -26,10 +26,10 @@ describe('ConstatationSuccess.vue', () => {
 
     expect(screen.getByText('Constatation enregistrée !')).toBeInTheDocument()
     expect(
-      screen.getByText(/La constatation du dépôt sauvage a bien été enregistrée/)
+      screen.getByText(/Vos documents de procédure ont été pré-remplis automatiquement/)
     ).toBeInTheDocument()
     expect(
-      screen.getByText('Consulter les prochaines étapes sur mon suivi de procédure')
+      screen.getByText('Accéder aux documents sur mon suivi de procédure')
     ).toBeInTheDocument()
 
     const modifyLink = screen.getByText('Modifier la constatation')

--- a/frontend/utils/tally.ts
+++ b/frontend/utils/tally.ts
@@ -66,3 +66,26 @@ export const closeTallyPopup = (formId: string) => {
     window.Tally.closePopup(formId)
   }
 }
+
+export const loadTallyEmbeds = () => {
+  const tryLoad = () => {
+    if (typeof window !== 'undefined' && window.Tally) {
+      window.Tally.loadEmbeds()
+      return true
+    }
+    return false
+  }
+
+  if (!tryLoad()) {
+    let attempts = 0
+    const interval = setInterval(() => {
+      attempts++
+      if (tryLoad() || attempts >= 20) {
+        clearInterval(interval)
+        if (attempts >= 20 && !window.Tally) {
+          console.warn('Tally script is not loaded yet after 2 seconds.')
+        }
+      }
+    }, 100)
+  }
+}


### PR DESCRIPTION
## Résumé
- Ajoute un formulaire Tally ("Donnez votre avis en 10 secondes") sur l'écran de fin de constatation, sous le lien "Modifier la constatation".
- Le formulaire est pré-rempli avec la commune et l'identifiant du dossier. **Aucune donnée personnelle identifiante n'est transmise** : l'email a été volontairement exclu après vérification de la page "Données personnelles", qui ne déclare pas Tally comme destinataire des données.
- Réutilise le mécanisme de chargement du script Tally déjà existant dans le projet (`frontend/utils/tally.ts`, script déjà chargé globalement dans `index.html`) : pas de nouvelle dépendance, pas de changement CSP nécessaire (`tally.so` était déjà autorisé).
- **Adoucit le message affiché juste après l'enregistrement** : l'ancien encart jaune "Attention la procédure n'est pas terminée !" (style alerte/erreur) est remplacé par un encart bleu "info" compact, sans titre en gras, pour une étape normale du parcours plutôt qu'un avertissement. Le texte de description et le libellé du bouton principal sont également reformulés pour refléter que les documents sont déjà pré-remplis et accessibles depuis le suivi de procédure.

## Avant / après
- **Avant** : l'écran de fin de constatation affichait "La constatation du dépôt sauvage a bien été enregistrée...", un encart jaune "Attention la procédure n'est pas terminée !", le bouton "Consulter les prochaines étapes sur mon suivi de procédure", et le lien "Modifier la constatation".
- **Après** : description reformulée ("Vos documents de procédure ont été pré-remplis automatiquement. Vous pouvez passer aux prochaines étapes."), encart bleu compact ("Le(s) document(s) doivent être signés par la personne habilitée pour avoir une valeur juridique."), bouton renommé "Accéder aux documents sur mon suivi de procédure", et un bloc "Donnez votre avis en 10 secondes" (formulaire Tally intégré, non bloquant, centré) sous le lien "Modifier la constatation".

## Checklist (CLAUDE.md)
- [x] Branche nommée selon conventionalbranch.org (`feat/mesure-utilisabilite-constatation`)
- [x] Un seul objectif produit pour cette PR (mesure d'utilisabilité en fin de constatation, y compris l'ajustement de ton du message associé)
- [x] Aucun changement à l'authentification, aux modèles de données, à la génération documentaire, ou à la logique métier
- [x] Responsive vérifié (desktop / mobile)
- [x] Testé en local (Docker) : rendu, responsive, et soumission réelle du formulaire (avis 3 étoiles + commentaire) vérifiés de bout en bout, aucune erreur console
- [x] Vérification RGPD : aucune donnée personnelle identifiante transmise à un tiers non déclaré

🤖 Généré avec [Claude Code](https://claude.com/claude-code)