### PR TITLE
feat: popup de mesure d'utilité pour initier une procédure

### DIFF
--- a/frontend/pages/suivi-procedure.vue
+++ b/frontend/pages/suivi-procedure.vue
@@ -120,7 +120,10 @@ import { API_URLS, fetchResource, getUserInfo } from '../services/api'
 import { getDocConstatUrl, getLettreInfoUrl } from '../services/urls'
 import { useSuiviStore } from '../stores/suivi-procedure'
 import { debounce } from '../utils/debounce'
-import { getStepTitles } from '../utils/procedure-steps'
+import { openTallyPopup } from '../utils/tally'
+
+// Formulaire de mesure de l'utilité de l'outil pour initier une procédure
+const UTILITE_INITIATION_PROCEDURE_FORM_ID = 'OD9RMg'
 
 const route = useRoute()
 const router = useRouter()
@@ -159,6 +162,27 @@ watch(
     debouncedSave()
   },
   { deep: true }
+)
+
+// Popup de mesure de l'utilité de l'outil, dès que la lettre d'information a été envoyée
+// (procédure effectivement lancée), en excluant les dossiers de test.
+const shouldShowUtiliteSurvey = computed(
+  () => suiviProcedure.value.lettre_envoyee && procedureData.value?.ceci_est_un_test !== true
+)
+
+watch(
+  shouldShowUtiliteSurvey,
+  (show) => {
+    if (show) {
+      openTallyPopup(UTILITE_INITIATION_PROCEDURE_FORM_ID, {
+        layout: 'default',
+        doNotShowAfterSubmit: true,
+        hideTitle: true,
+        autoClose: 2000,
+      })
+    }
+  },
+  { immediate: true }
 )
 
 const getStepStatus = (index: number) =>

--- a/frontend/tests/suivi-procedure.test.ts
+++ b/frontend/tests/suivi-procedure.test.ts
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SuiviProcedurePage from '../pages/suivi-procedure.vue'
 import * as api from '../services/api'
+import * as tally from '../utils/tally'
 
 vi.mock('../services/api', async () => {
   const actual = await vi.importActual('../services/api')
@@ -11,6 +12,14 @@ vi.mock('../services/api', async () => {
     ...actual,
     getUserInfo: vi.fn(),
     fetchResource: vi.fn(),
+  }
+})
+
+vi.mock('../utils/tally', async () => {
+  const actual = await vi.importActual('../utils/tally')
+  return {
+    ...actual,
+    openTallyPopup: vi.fn(),
   }
 })
 
@@ -165,6 +174,102 @@ describe('Page Suivi de Procédure', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('identification-step')).toBeInTheDocument()
+    })
+  })
+
+  describe('Popup de mesure d’utilité (lettre d’information envoyée)', () => {
+    const stubs = {
+      StepperProcedure: {
+        props: ['steps', 'currentStep'],
+        template: '<div data-testid="stepper"><slot :name="`step-${currentStep}`" /></div>',
+      },
+      Chargement: true,
+      LoginInvitation: true,
+      DsfrBadge: true,
+      DsfrButton: true,
+      Metadata: true,
+      InfosComplementaires: true,
+      Notification: {
+        props: ['lettreInfoUrl'],
+        template: '<div data-testid="notification-step" />',
+      },
+    }
+
+    const mockFetch = (constatationOverrides: Record<string, unknown> = {}) => {
+      ;(api.fetchResource as any).mockImplementation((url: string) => {
+        if (url.includes('/suivi-procedure/')) {
+          return Promise.resolve({ etape_en_cours: 2, lettre_envoyee: true })
+        }
+        return Promise.resolve({
+          id: 163,
+          created: true,
+          auteur_identifie: true,
+          commune: 'Amiens',
+          date_constat: '2026-03-27',
+          ...constatationOverrides,
+        })
+      })
+    }
+
+    it('ouvre le popup Tally quand la lettre est envoyée sur un vrai dossier', async () => {
+      ;(api.getUserInfo as any).mockResolvedValue({ is_authenticated: true })
+      mockFetch({ ceci_est_un_test: false })
+
+      render(SuiviProcedurePage, {
+        global: { plugins: [createTestingPinia({ stubActions: false })], stubs },
+      })
+
+      await waitFor(() => {
+        expect(tally.openTallyPopup).toHaveBeenCalledWith(
+          'OD9RMg',
+          expect.objectContaining({
+            layout: 'default',
+            doNotShowAfterSubmit: true,
+            hideTitle: true,
+            autoClose: 2000,
+          })
+        )
+      })
+    })
+
+    it("n'ouvre pas le popup Tally sur un dossier de test", async () => {
+      ;(api.getUserInfo as any).mockResolvedValue({ is_authenticated: true })
+      mockFetch({ ceci_est_un_test: true })
+
+      render(SuiviProcedurePage, {
+        global: { plugins: [createTestingPinia({ stubActions: false })], stubs },
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('notification-step')).toBeInTheDocument()
+      })
+      expect(tally.openTallyPopup).not.toHaveBeenCalled()
+    })
+
+    it("n'ouvre pas le popup Tally tant que la lettre n'a pas été envoyée", async () => {
+      ;(api.getUserInfo as any).mockResolvedValue({ is_authenticated: true })
+      ;(api.fetchResource as any).mockImplementation((url: string) => {
+        if (url.includes('/suivi-procedure/')) {
+          return Promise.resolve({ etape_en_cours: 2, lettre_envoyee: false })
+        }
+        return Promise.resolve({
+          id: 163,
+          created: true,
+          auteur_identifie: true,
+          commune: 'Amiens',
+          date_constat: '2026-03-27',
+          ceci_est_un_test: false,
+        })
+      })
+
+      render(SuiviProcedurePage, {
+        global: { plugins: [createTestingPinia({ stubActions: false })], stubs },
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('notification-step')).toBeInTheDocument()
+      })
+      expect(tally.openTallyPopup).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Résumé

- Ajoute un popup Tally ("Utilité pour initier une procédure", formulaire `OD9RMg`) sur la page de suivi de procédure.
- Se déclenche dès que l'utilisateur coche la case *"Envoyer la lettre d'information en recommandé avec accusé de réception"* (= la procédure est effectivement lancée), uniquement sur les dossiers réels (les dossiers de test sont exclus via `ceci_est_un_test`).
- Le popup s'affiche en bas à droite, titre masqué, se ferme automatiquement 2s après soumission, et ne réapparaît plus une fois que l'utilisateur y a répondu (`doNotShowAfterSubmit`).

## Test plan

- [x] Tests automatisés ajoutés dans `frontend/tests/suivi-procedure.test.ts` (popup déclenché sur vrai dossier / non déclenché sur dossier test / non déclenché tant que la lettre n'est pas envoyée) — tous passent.
- [x] Vérifié manuellement en local (Docker) : popup affiché en bas à droite au bon moment, avec les bons réglages Tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
